### PR TITLE
update associate command

### DIFF
--- a/catalyze.markdown
+++ b/catalyze.markdown
@@ -26,8 +26,8 @@ Heroku ever would, but we'll see.
    access to our Catalyze wrapper script (`bin/catalyze.sh`):
 
    ```
-   $ bin/catalyze.sh associate healthproprod
-   $ bin/catalyze.sh associate healthprostaging
+   $ bin/catalyze.sh associate healthproprod app01
+   $ bin/catalyze.sh associate healthprostaging app01
    ```
 
 1. Ensure you are logged into the right Catalyze user and have access:


### PR DESCRIPTION
Whoops, sorry for the lame branch name.
# Problem

Running the associate command found in the guide `./bin/catalyze.sh associate healthproprod` generated an incorrect usage error. Not sure if this is due to a CLI update or just lag between when we actually did that first-time setup and when the guide was produced, but evidently it now requires the app ID/name also.
# Solution

\+ `app01`
