### PR TITLE
add step needed to fix git rev-parse error

### DIFF
--- a/catalyze.markdown
+++ b/catalyze.markdown
@@ -37,8 +37,8 @@ Heroku ever would, but we'll see.
    
 1. Fetch the new remotes so `git rev-parse prod/master` and `git rev-parse staging/master` don't fail in `deploy.sh`:
    ```
-   $ git fetch prod/master
-   $ git fetch staging/master
+   $ git fetch prod
+   $ git fetch staging
    ```
 
 1. *Optional*: Pick a default environment to associate with. We generally

--- a/catalyze.markdown
+++ b/catalyze.markdown
@@ -34,6 +34,12 @@ Heroku ever would, but we'll see.
    $ bin/catalyze.sh associate healthproprod onboarding01
    $ bin/catalyze.sh associate healthprostaging onboarding01
    ```
+   
+1. Fetch the new remotes so `git rev-parse prod/master` and `git rev-parse staging/master` don't fail in `deploy.sh`:
+   ```
+   $ git fetch prod/master
+   $ git fetch staging/master
+   ```
 
 1. *Optional*: Pick a default environment to associate with. We generally
    would recommend using the staging environment since that is least likely


### PR DESCRIPTION
# Problem

When running `./bin/deploy.sh staging master` I was getting this error:

```
fatal: ambiguous argument 'staging/master': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

the command generating this error was `git rev-parse staging/master` - this was because I'd never `git fetch staging/master` and git apparently isn't smart enough to go look for it despite correct remote configuration.
# Solution

`git fetch staging/master` and/or `git fetch prod/master` - I don't remember if I had to do that as part of catalyze setup for RMS, but seems like a thing that should be documented.
