### PR TITLE
Add instructions to test Salesforce permissions/connectivity

### DIFF
--- a/catalyze.markdown
+++ b/catalyze.markdown
@@ -118,6 +118,34 @@ can get some high-level stats using `bin/catalyze.sh metrics` and
 
     $ bin/catalyze.sh console db01
 
+### Verify Salesforce permissions and connectivity
+
+We use Salesforce as a backend in some environments. To verify that our user
+has the correct field-level permissions (was a problem a few times when using
+change sets), run the following script, updating the collection and name fields
+as appropriate:
+
+    $ ./bin/catalyze.sh -E <environment> "bundle exec irb"
+    ...
+    require 'restforce'
+    client = Restforce.new
+    collection = 'Contact'
+    name = 'Updated_Terms_Of_Service_At__c'
+    described = client.describe(collection)
+    described.fields.map(&:name).include?(name)
+
+The result of running this should be "true".
+
+To verify that our Salesforce credentials are correct, try:
+
+    $ ./bin/catalyze.sh -E <environment> "bundle exec irb"
+    ...
+    require 'restforce'
+    client = Restforce.new
+    described = client.describe('Contact')
+
+It should spit out a long string of fields, not an error.
+
 ## Debugging Tips
 
 The first time you deploy code to a new environment, Catalyze needs to


### PR DESCRIPTION
This tackles [this Trello card](https://trello.com/c/TaODjkos/541-create-a-task-rake-or-otherwise-to-quickly-confirm-that-an-environment-has-readable-permissions-for-a-given-field) and, in a kind of hacky way, [this Trello card](https://trello.com/c/8wagijHO/543-test-somewhere-in-the-deploy-process-or-test-suite-that-actually-hits-salesforce-to-verify-credentials-are-correct).

Basically we just make a pastable set of commands that we run at the IRB console. This saves us from having a duplicate rake or other task in multiple environments.
